### PR TITLE
updating bucket for logs

### DIFF
--- a/infra/prod/index.ts
+++ b/infra/prod/index.ts
@@ -321,7 +321,7 @@ const alb = new aws.alb.LoadBalancer(`scorer-service`, {
   securityGroups: [albSecGrp.id],
   subnets: vpcPublicSubnetIds,
   accessLogs: {
-    bucket: accessLogsBucket.bucket,
+    bucket: "arn:aws:s3:::datadog-forwarder-us-west-2-forwarderbucket-lsppwrzazepk",
     enabled: true,
   },
 });


### PR DESCRIPTION
This redirects logs to the Datadog forwarder bucket which should take care of forwarding them.