### PR TITLE
fix: rmeove import of numpy in v2 score handler

### DIFF
--- a/api/v2/aws_lambdas/stamp_score_GET.py
+++ b/api/v2/aws_lambdas/stamp_score_GET.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 
 from asgiref.sync import async_to_sync
 from django.db import close_old_connections
-from numpy import add
 
 from aws_lambdas.utils import (
     with_api_request_exception_handling,


### PR DESCRIPTION

Fixes: https://github.com/passportxyz/passport/issues/3093
