### PR TITLE
fix: failing tests because of removed 'hash' attribute in Stamp

### DIFF
--- a/api/v2/test/test_passport_submission.py
+++ b/api/v2/test/test_passport_submission.py
@@ -414,10 +414,6 @@ class ValidatePassportTestCase(TransactionTestCase):
 
         self.assertEqual(stamp_ens.credential, ens_credential)
         self.assertEqual(stamp_google.credential, google_credential)
-        self.assertEqual(stamp_ens.hash, ens_credential["credentialSubject"]["hash"])
-        self.assertEqual(
-            stamp_google.hash, google_credential["credentialSubject"]["hash"]
-        )
 
     @patch("registry.atasks.validate_credential", side_effect=[[], []])
     @patch(


### PR DESCRIPTION

Fixes: https://github.com/passportxyz/passport/issues/3189
