### PR TITLE
fix: drop cache specification for yarn generic workflow

### DIFF
--- a/.github/workflows/build_and_deploy_generic.yml
+++ b/.github/workflows/build_and_deploy_generic.yml
@@ -197,7 +197,6 @@ jobs:
         with:
           # Lambda is currently running on node 20
           node-version: 20
-          cache: "yarn"
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
@@ -274,7 +273,6 @@ jobs:
         with:
           # Lambda is currently running on node 20
           node-version: 20
-          cache: "yarn"
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"


### PR DESCRIPTION

Fixes: https://github.com/passportxyz/passport/issues/3172
