### PR TITLE
fix: typo in mem allocation

### DIFF
--- a/infra/aws/index.ts
+++ b/infra/aws/index.ts
@@ -314,7 +314,7 @@ const ecsTaskConfigurations: Record<
       cpu: 256,
     },
     production: {
-      memory: 4095,
+      memory: 4096,
       cpu: 512,
     },
   },


### PR DESCRIPTION

Fixes: https://github.com/passportxyz/passport/issues/3380
