### PR TITLE
fix: remove multiplier from points calculation in get_user_points_data

### DIFF
--- a/api/registry/human_points_utils.py
+++ b/api/registry/human_points_utils.py
@@ -37,7 +37,7 @@ def get_user_points_data(address: str) -> Dict:
             hp.address,
             hp.action,
             hp.chain_id,
-            SUM(hpc.points * COALESCE(hpm.multiplier, 1)) as action_points,
+            SUM(hpc.points) as action_points,
             MAX(COALESCE(hpm.multiplier, 1)) as multiplier
         FROM registry_humanpoints hp
         INNER JOIN registry_humanpointsconfig hpc

--- a/api/registry/test/test_human_points_api_response.py
+++ b/api/registry/test/test_human_points_api_response.py
@@ -188,19 +188,19 @@ class TestHumanPointsAPIResponse:
             assert "points_data" in data
             points_data = data["points_data"]
 
-            # Verify points data structure
-            assert points_data["total_points"] == 1400  # (100 + 100) * 2 + 500 * 2
+            # Verify points data structure - now using raw points without multiplication
+            assert points_data["total_points"] == 700  # 100 + 100 + 500 (raw points)
             assert points_data["is_eligible"] is True  # passing_scores >= 1
             assert points_data["multiplier"] == 2
 
-            # Check breakdown structure
+            # Check breakdown structure - now using raw points without multiplication
             assert "breakdown" in points_data
             breakdown = points_data["breakdown"]
-            assert breakdown[HumanPoints.Action.HUMAN_KEYS] == 200  # 100 * 2
+            assert breakdown[HumanPoints.Action.HUMAN_KEYS] == 100  # raw points
             assert (
-                breakdown[HumanPoints.Action.IDENTITY_STAKING_BRONZE] == 200
-            )  # 100 * 2
-            assert breakdown[HumanPoints.Action.SCORING_BONUS] == 1000  # 500 * 2
+                breakdown[HumanPoints.Action.IDENTITY_STAKING_BRONZE] == 100
+            )  # raw points
+            assert breakdown[HumanPoints.Action.SCORING_BONUS] == 500  # raw points
 
     @patch("ceramic_cache.api.v1.settings.HUMAN_POINTS_ENABLED", True)
     def test_ceramic_cache_score_endpoint_includes_points_data_and_chain_id(
@@ -240,20 +240,20 @@ class TestHumanPointsAPIResponse:
             assert "points_data" in data
             points_data = data["points_data"]
 
-            # Verify points data structure
-            assert points_data["total_points"] == 900
+            # Verify points data structure - now using raw points without multiplication
+            assert points_data["total_points"] == 800  # 100*3 + 100 + 500 (raw points)
             assert points_data["is_eligible"] is True  # passing_scores >= 1
             assert points_data["multiplier"] == 1
 
-            # Check breakdown structure
+            # Check breakdown structure - now using raw points without multiplication
             assert "breakdown" in points_data
             breakdown = points_data["breakdown"]
-            assert breakdown[HumanPoints.Action.PASSPORT_MINT] == 300  # 300
-            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_1"] == 100  # 100
-            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_1"] == 100  # 100
-            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_1"] == 100  # 100
-            assert breakdown[HumanPoints.Action.IDENTITY_STAKING_BRONZE] == 100  # 100
-            assert breakdown[HumanPoints.Action.SCORING_BONUS] == 500  # 500
+            assert breakdown[HumanPoints.Action.PASSPORT_MINT] == 300  # 100*3 (raw points)
+            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_1"] == 100  # raw points
+            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_2"] == 100  # raw points
+            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_3"] == 100  # raw points
+            assert breakdown[HumanPoints.Action.IDENTITY_STAKING_BRONZE] == 100  # raw points
+            assert breakdown[HumanPoints.Action.SCORING_BONUS] == 500  # raw points
 
     @patch("ceramic_cache.api.v1.settings.HUMAN_POINTS_ENABLED", True)
     def test_points_data_for_non_eligible_address(

--- a/api/registry/test/test_human_points_api_response.py
+++ b/api/registry/test/test_human_points_api_response.py
@@ -241,19 +241,19 @@ class TestHumanPointsAPIResponse:
             points_data = data["points_data"]
 
             # Verify points data structure - now using raw points without multiplication
-            assert points_data["total_points"] == 800  # 100*3 + 100 + 500 (raw points)
+            assert points_data["total_points"] == 900 
             assert points_data["is_eligible"] is True  # passing_scores >= 1
             assert points_data["multiplier"] == 1
 
             # Check breakdown structure - now using raw points without multiplication
             assert "breakdown" in points_data
             breakdown = points_data["breakdown"]
-            assert breakdown[HumanPoints.Action.PASSPORT_MINT] == 300  # 100*3 (raw points)
-            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_1"] == 100  # raw points
-            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_2"] == 100  # raw points
-            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_3"] == 100  # raw points
-            assert breakdown[HumanPoints.Action.IDENTITY_STAKING_BRONZE] == 100  # raw points
-            assert breakdown[HumanPoints.Action.SCORING_BONUS] == 500  # raw points
+            assert breakdown[HumanPoints.Action.PASSPORT_MINT] == 300
+            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_1"] == 100
+            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_2"] == 100
+            assert breakdown[f"{HumanPoints.Action.PASSPORT_MINT}_3"] == 100
+            assert breakdown[HumanPoints.Action.IDENTITY_STAKING_BRONZE] == 100
+            assert breakdown[HumanPoints.Action.SCORING_BONUS] == 500 
 
     @patch("ceramic_cache.api.v1.settings.HUMAN_POINTS_ENABLED", True)
     def test_points_data_for_non_eligible_address(

--- a/api/registry/test/test_human_points_models.py
+++ b/api/registry/test/test_human_points_models.py
@@ -361,7 +361,7 @@ class TestHumanPointsIntegration:
             address=address, action=HumanPoints.Action.SCORING_BONUS
         )
 
-        # Calculate total with normalized approach
+        # Calculate total with normalized approach - now using raw points without multiplication
         actions = HumanPoints.objects.filter(address=address)
         multiplier = HumanPointsMultiplier.objects.get(address=address)
 
@@ -370,9 +370,9 @@ class TestHumanPointsIntegration:
             config = HumanPointsConfig.objects.get(
                 action=action_record.action, active=True
             )
-            total += config.points * multiplier.multiplier
+            total += config.points  # No multiplication
 
-        assert total == 1400  # (100 + 100) * 2 + 500 * 2
+        assert total == 700  # 100 + 100 + 500 (raw points)
 
     def test_check_eligibility(self, scorer_community):
         """Test checking if an address is eligible (has at least 1 passing score)"""


### PR DESCRIPTION
## Description
Removes the multiplier from points calculation in the `get_user_points_data` function.

## Changes
- Modified SQL query in `registry/human_points_utils.py` to use `SUM(hpc.points)` instead of `SUM(hpc.points * COALESCE(hpm.multiplier, 1))`
- Points breakdown now returns raw values without multiplication
- Total points calculation remains mathematically correct as sum of raw values
- Multiplier is still retrieved and returned for frontend reference

## Testing
- Points data will now show raw values (e.g., CSB: 100 instead of 200 with 2x multiplier)
- Total points will be sum of raw values
- Multiplier field still available for frontend use

## Impact
- Frontend will receive un-multiplied point values in breakdown
- No breaking changes to API structure