### PR TITLE
fix: replace retired gitcoin.co hosts with their passport.xyz equivalents

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ The Passport Scorer API (this repository) is a centralized service provided by P
 ## Quick Links
 
 - [Passport Docs](https://docs.passport.xyz/)
-- [API Docs](https://api.scorer.gitcoin.co/docs)
+- [API Docs](https://api.passport.xyz/docs)
 - [Official Website](https://www.passport.xyz?utm_source=scorer-api-repo&utm_medium=referral&utm_content=Passport)
 
 ## Contributing

--- a/Readme.md
+++ b/Readme.md
@@ -8,9 +8,9 @@ The Passport Scorer API (this repository) is a centralized service provided by P
 
 ## Quick Links
 
-- [Passport Docs](https://docs.passport.xyz/)
+- [Passport Docs](https://docs.passport.human.tech/)
 - [API Docs](https://api.passport.xyz/docs)
-- [Official Website](https://www.passport.xyz?utm_source=scorer-api-repo&utm_medium=referral&utm_content=Passport)
+- [Official Website](https://passport.human.tech?utm_source=scorer-api-repo&utm_medium=referral&utm_content=Passport)
 
 ## Contributing
 

--- a/api/.env-sample
+++ b/api/.env-sample
@@ -39,7 +39,7 @@ LOGGING_STRATEGY=structlog_json
 
 CERAMIC_CACHE_SCORER_ID=
 
-PASSPORT_PUBLIC_URL=https://passport.gitcoin.co/
+PASSPORT_PUBLIC_URL=https://app.passport.xyz/
 
 # TRUSTED_IAM_ISSUER is deprecated in favor of TRUSTED_IAM_ISSUERS
 TRUSTED_IAM_ISSUER=

--- a/api/registry/api/v1.py
+++ b/api/registry/api/v1.py
@@ -593,7 +593,7 @@ def get_passport_stamps(
     summary="Programmatically create a generic scorer",
     description="""This endpoint allows the creation of new scorers.\n
 You must have the correct permissions to make requests to this endpoint.\n
-Anyone can go to https://www.scorer.gitcoin.co/ and create a new scorer via the UI.\n
+Anyone can go to https://developer.passport.xyz/ and create a new scorer via the UI.\n
 """,
 )
 def create_generic_scorer(request, payload: GenericCommunityPayload):

--- a/api/registry/bulk-mbd-analysis.md
+++ b/api/registry/bulk-mbd-analysis.md
@@ -4,14 +4,14 @@ This document outlines the process for uploading a CSV file to the Django admin 
 
 ## Prerequisites
 
-- Access to the Django admin interface at api.scorer.gitcoin.co
+- Access to the Django admin interface at api.passport.xyz
 - A CSV file containing the data to be processed
 
 ## Steps
 
 ### 1. Login to Django Admin
 
-1. Open your web browser and navigate to [api.scorer.gitcoin.co/admin](https://api.scorer.gitcoin.co/admin)
+1. Open your web browser and navigate to [api.passport.xyz/admin](https://api.passport.xyz/admin)
 2. Log in with your google account
 
 ### 2. Navigate to Batch Model Scoring Request

--- a/api/v2/api/api_stamps.py
+++ b/api/v2/api/api_stamps.py
@@ -373,7 +373,7 @@ def format_v2_score_response(
     },
     operation_id="v2_api_api_stamps_a_submit_passport",
     summary="Retrieve Stamp-based unique humanity score for a specified address",
-    description="""This is the primary endpoint that integrators should use. This endpoint will return the latest score and Stamp data for a single address.<br /><br /><a href="https://docs.passport.xyz/building-with-passport/passport-api-v2/api-reference" target="_blank">Docs</a>""",
+    description="""This is the primary endpoint that integrators should use. This endpoint will return the latest score and Stamp data for a single address.<br /><br /><a href="https://docs.passport.human.tech/building-with-passport/passport-api-v2/api-reference" target="_blank">Docs</a>""",
     tags=["Stamp API"],
 )
 @atrack_apikey_usage(track_response=True)
@@ -440,7 +440,7 @@ class EventFilter(django_filters.FilterSet):
     },
     operation_id="v2_api_api_stamps_get_score_history",
     summary="Retrieve historical Stamp-based unique humanity score for a specified address",
-    description="""This endpoint will return the historical score and Stamp data for a single address at a specified time. **Note:** To access this endpoint, you must submit your use case and be approved by the Passport team. To do so, please fill out the following form, making sure to provide a detailed description of your use case. The Passport team typically reviews and responds to form responses within 48 hours.<br /><br />[Request access](https://forms.gle/4GyicBfhtHW29eEu8)<br /><br /><a href="https://docs.passport.xyz/building-with-passport/passport-api-v2/api-reference" target="_blank">Docs</a>""",
+    description="""This endpoint will return the historical score and Stamp data for a single address at a specified time. **Note:** To access this endpoint, you must submit your use case and be approved by the Passport team. To do so, please fill out the following form, making sure to provide a detailed description of your use case. The Passport team typically reviews and responds to form responses within 48 hours.<br /><br />[Request access](https://forms.gle/4GyicBfhtHW29eEu8)<br /><br /><a href="https://docs.passport.human.tech/building-with-passport/passport-api-v2/api-reference" target="_blank">Docs</a>""",
     tags=["Stamp API"],
 )
 @track_apikey_usage(track_response=False)
@@ -518,7 +518,7 @@ def get_score_history(
 @api_router.get(
     "/stamps/metadata",
     summary="Receive all Stamps available in Passport",
-    description="""<a href="https://docs.passport.xyz/building-with-passport/passport-api-v2/api-reference" target="_blank">Docs</a>""",
+    description="""<a href="https://docs.passport.human.tech/building-with-passport/passport-api-v2/api-reference" target="_blank">Docs</a>""",
     auth=ApiKey(),
     response={
         200: List[StampDisplayResponse],
@@ -543,7 +543,7 @@ def stamp_display(request) -> List[StampDisplayResponse]:
     },
     operation_id="v2_api_api_stamps_get_passport_stamps",
     summary="Retrieve the Stamps that a specified account has verified.",
-    description="""Use this endpoint to retrieve the Stamps verified by a specified address.<br /><br />This endpoint will return a `CursorPaginatedStampCredentialResponse`.<br /><br /><a href="https://docs.passport.xyz/building-with-passport/passport-api-v2/api-reference" target="_blank">Docs</a>""",
+    description="""Use this endpoint to retrieve the Stamps verified by a specified address.<br /><br />This endpoint will return a `CursorPaginatedStampCredentialResponse`.<br /><br /><a href="https://docs.passport.human.tech/building-with-passport/passport-api-v2/api-reference" target="_blank">Docs</a>""",
     exclude_unset=True,
     tags=["Stamp API"],
 )

--- a/examples/airdrop/README.md
+++ b/examples/airdrop/README.md
@@ -8,7 +8,7 @@ This sample app connects to a user's wallet, then fetches their passport score f
 
 ### Create your API key and Scorer
 
-1. Create your API key by going to [Gitcoin Passport Scorer](https://scorer.gitcoin.co) and clicking on the "API Keys" section.
+1. Create your API key by going to [Gitcoin Passport Scorer](https://developer.passport.xyz) and clicking on the "API Keys" section.
    Then create a `.env.local` file and copy the contents of the `example.local.env` file into it.
    Replace `SCORER_API_KEY` with your API key.
 

--- a/examples/airdrop/components/AirDrop.js
+++ b/examples/airdrop/components/AirDrop.js
@@ -32,7 +32,7 @@ export default function AirDrop() {
   async function addToAirdrop() {
     setNonce("");
     setPassportScore(0);
-    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
     //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
     //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
     //    expose our scorer API key to the frontend.

--- a/examples/airdrop/components/AirDrop.js
+++ b/examples/airdrop/components/AirDrop.js
@@ -32,7 +32,7 @@ export default function AirDrop() {
   async function addToAirdrop() {
     setNonce("");
     setPassportScore(0);
-    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
+    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.human.tech/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
     //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
     //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
     //    expose our scorer API key to the frontend.

--- a/examples/airdrop/components/AirDrop.js
+++ b/examples/airdrop/components/AirDrop.js
@@ -32,7 +32,7 @@ export default function AirDrop() {
   async function addToAirdrop() {
     setNonce("");
     setPassportScore(0);
-    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.gitcoin.co/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
     //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
     //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
     //    expose our scorer API key to the frontend.
@@ -73,7 +73,7 @@ export default function AirDrop() {
       //    }
       const submitResponse = await axios.post("/api/submit-passport", {
         address: address, // Required: The user's address you'd like to score.
-        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://scorer.gitcoin.co/
+        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://developer.passport.xyz/
         signature: data, // Optional: The signature of the message returned in Step #1
         nonce: nonce, // Optional: The nonce returned in Step #1
       });
@@ -151,7 +151,7 @@ export default function AirDrop() {
                   className={styles.link}
                   target="_blank"
                   rel="noreferrer"
-                  href="https://passport.gitcoin.co"
+                  href="https://app.passport.xyz"
                 >
                   Click here to increase your score.
                 </a>

--- a/examples/airdrop/pages/admin/dashboard.js
+++ b/examples/airdrop/pages/admin/dashboard.js
@@ -123,7 +123,7 @@ export default function Dashboard({ data }) {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.gitcoin.co/"
+              href="https://www.passport.xyz/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/airdrop/pages/admin/dashboard.js
+++ b/examples/airdrop/pages/admin/dashboard.js
@@ -123,7 +123,7 @@ export default function Dashboard({ data }) {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.passport.xyz/"
+              href="https://passport.human.tech/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/airdrop/pages/admin/theme.js
+++ b/examples/airdrop/pages/admin/theme.js
@@ -46,7 +46,7 @@ export default function Theme() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.passport.xyz/"
+              href="https://passport.human.tech/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/airdrop/pages/admin/theme.js
+++ b/examples/airdrop/pages/admin/theme.js
@@ -46,7 +46,7 @@ export default function Theme() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.gitcoin.co/"
+              href="https://www.passport.xyz/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/airdrop/pages/api/airdrop/add/[scorer_id]/[address].js
+++ b/examples/airdrop/pages/api/airdrop/add/[scorer_id]/[address].js
@@ -23,7 +23,7 @@ async function fetchScore(address, scorerId) {
     },
   };
   const { data } = await axios.get(
-    `https://api.scorer.gitcoin.co/registry/score/${scorerId}/${address}`,
+    `https://api.passport.xyz/registry/score/${scorerId}/${address}`,
     axiosGetScoreConfig
   );
 

--- a/examples/airdrop/pages/api/scorer-message.js
+++ b/examples/airdrop/pages/api/scorer-message.js
@@ -17,7 +17,7 @@ async function fetchMessageAndNonce() {
     },
   };
   const { data } = await axios.get(
-    "https://api.scorer.gitcoin.co/registry/signing-message",
+    "https://api.passport.xyz/registry/signing-message",
     axiosSigningMessageConfig
   );
   return data;

--- a/examples/airdrop/pages/api/submit-passport.js
+++ b/examples/airdrop/pages/api/submit-passport.js
@@ -22,7 +22,7 @@ async function submitPassport(address, community, signature, nonce) {
     nonce,
   };
   const { data } = await axios.post(
-    "https://api.scorer.gitcoin.co/registry/submit-passport",
+    "https://api.passport.xyz/registry/submit-passport",
     axiosSubmitPassportData,
     axiosSubmitPassportConfig
   );

--- a/examples/airdrop/pages/index.js
+++ b/examples/airdrop/pages/index.js
@@ -39,7 +39,7 @@ export default function Home() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.passport.xyz/"
+              href="https://passport.human.tech/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/airdrop/pages/index.js
+++ b/examples/airdrop/pages/index.js
@@ -39,7 +39,7 @@ export default function Home() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.gitcoin.co/"
+              href="https://www.passport.xyz/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/check-trusted-user-app/README.md
+++ b/examples/check-trusted-user-app/README.md
@@ -6,7 +6,7 @@ from Gitcoin passport. The app is built in Nextjs using `create-next-app` and Ch
 
 ## Getting Started
 
-This repository contains source code to accompany a "trusted user app" walkthrouhg tutorial at [docs.passport.xyz](https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/tutorials/integrating-stamps-and-scorers).
+This repository contains source code to accompany a "trusted user app" walkthrouhg tutorial at [docs.passport.human.tech](https://docs.passport.human.tech/building-with-passport/stamps/passport-api-v1/tutorials/integrating-stamps-and-scorers).
 
 You can find step-by-step instructions for setting up and running this app in the tutorial.
 

--- a/examples/check-trusted-user-app/README.md
+++ b/examples/check-trusted-user-app/README.md
@@ -6,7 +6,7 @@ from Gitcoin passport. The app is built in Nextjs using `create-next-app` and Ch
 
 ## Getting Started
 
-This repository contains source code to accompany a "trusted user app" walkthrouhg tutorial at [docs.passport.xyz](https://docs.passport.xyz/building-with-passport/integration-guides/integrating-stamps-and-scorers).
+This repository contains source code to accompany a "trusted user app" walkthrouhg tutorial at [docs.passport.xyz](https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/tutorials/integrating-stamps-and-scorers).
 
 You can find step-by-step instructions for setting up and running this app in the tutorial.
 

--- a/examples/check-trusted-user-app/README.md
+++ b/examples/check-trusted-user-app/README.md
@@ -6,7 +6,7 @@ from Gitcoin passport. The app is built in Nextjs using `create-next-app` and Ch
 
 ## Getting Started
 
-This repository contains source code to accompany a "trusted user app" walkthrouhg tutorial at [docs.gitcoin.co](https://docs.passport.gitcoin.co/building-with-passport/integration-guides/integrating-stamps-and-scorers).
+This repository contains source code to accompany a "trusted user app" walkthrouhg tutorial at [docs.passport.xyz](https://docs.passport.xyz/building-with-passport/integration-guides/integrating-stamps-and-scorers).
 
 You can find step-by-step instructions for setting up and running this app in the tutorial.
 

--- a/examples/check-trusted-user-app/app/boilerplate.tsx
+++ b/examples/check-trusted-user-app/app/boilerplate.tsx
@@ -6,9 +6,9 @@ const APIKEY = process.env.NEXT_PUBLIC_GC_API_KEY
 const SCORERID = process.env.NEXT_PUBLIC_GC_SCORER_ID
 
 // endpoint for submitting passport
-const SUBMIT_PASSPORT_URI = 'https://api.scorer.gitcoin.co/registry/submit-passport'
+const SUBMIT_PASSPORT_URI = 'https://api.passport.xyz/registry/submit-passport'
 // endpoint for getting the signing message
-const SIGNING_MESSAGE_URI = 'https://api.scorer.gitcoin.co/registry/signing-message'
+const SIGNING_MESSAGE_URI = 'https://api.passport.xyz/registry/signing-message'
 // score needed to see hidden message
 const thresholdNumber = 20
 const headers = APIKEY ? ({

--- a/examples/check-trusted-user-app/app/boilerplate.tsx
+++ b/examples/check-trusted-user-app/app/boilerplate.tsx
@@ -147,7 +147,7 @@ export default function Passport() {
     /* this is the UI for the app */
     <div style={styles.main}>
       <h1 style={styles.heading}>Are you a trusted user? 🫶</h1>
-      <p style={styles.configurePassport}>Configure your passport <a style={styles.linkStyle} target="_blank" href="https://passport.gitcoin.co/#/dashboard">here</a></p>
+      <p style={styles.configurePassport}>Configure your passport <a style={styles.linkStyle} target="_blank" href="https://app.passport.xyz/#/dashboard">here</a></p>
       <p style={styles.configurePassport}>Once you've added more stamps to your passport, submit your passport again to recalculate your score.</p>
       <p style={styles.configurePassport}>If you have a score above 20, a Github stamp AND a Lens stamp, you are a trusted user! Click the Check Users button to find out!</p>
       <div style={styles.buttonContainer}>

--- a/examples/check-trusted-user-app/app/page.tsx
+++ b/examples/check-trusted-user-app/app/page.tsx
@@ -7,9 +7,9 @@ const APIKEY = process.env.NEXT_PUBLIC_GC_API_KEY
 const SCORERID = process.env.NEXT_PUBLIC_GC_SCORER_ID
 
 // endpoint for submitting passport
-const SUBMIT_PASSPORT_URI = 'https://api.scorer.gitcoin.co/registry/submit-passport'
+const SUBMIT_PASSPORT_URI = 'https://api.passport.xyz/registry/submit-passport'
 // endpoint for getting the signing message
-const SIGNING_MESSAGE_URI = 'https://api.scorer.gitcoin.co/registry/signing-message'
+const SIGNING_MESSAGE_URI = 'https://api.passport.xyz/registry/signing-message'
 // score needed to see hidden message
 const thresholdNumber = 20
 const headers = APIKEY ? ({
@@ -137,7 +137,7 @@ export default function Passport() {
 
   async function getPassportScore(currentAddress: string) {
     console.log("in getScore()")
-    const GET_PASSPORT_SCORE_URI = `https://api.scorer.gitcoin.co/registry/score/${SCORERID}/${currentAddress}`
+    const GET_PASSPORT_SCORE_URI = `https://api.passport.xyz/registry/score/${SCORERID}/${currentAddress}`
     try {
       const response = await fetch(GET_PASSPORT_SCORE_URI, {
         headers
@@ -159,7 +159,7 @@ export default function Passport() {
   async function getPassportStamps(currentAddress: string) {
     console.log("in getStamps()")
     const stampProviderArray = []
-    const GET_PASSPORT_STAMPS_URI = `https://api.scorer.gitcoin.co/registry/stamps/${currentAddress}`
+    const GET_PASSPORT_STAMPS_URI = `https://api.passport.xyz/registry/stamps/${currentAddress}`
     try {
       const response: Response = await fetch(GET_PASSPORT_STAMPS_URI, { headers })
       const data = await response.json()

--- a/examples/example-score-a-passport/Readme.md
+++ b/examples/example-score-a-passport/Readme.md
@@ -8,7 +8,7 @@
 
 # About this example
 
-This example demonstrates how to use the Gitcoin Passport Scoring API to score a user's Passport. It includes a form for the developer to input their community ID and API key, which they can obtain from their [Gitcoin Passport Scoring dashboard](https://www.scorer.gitcoin.co/). When the "Submit for scoring" button is clicked, the provided community ID and API key are used to make a GET request to the Gitcoin Passport Scoring API. The response from the API, which includes the user's Passport score, is then displayed on the page.
+This example demonstrates how to use the Gitcoin Passport Scoring API to score a user's Passport. It includes a form for the developer to input their community ID and API key, which they can obtain from their [Gitcoin Passport Scoring dashboard](https://developer.passport.xyz/). When the "Submit for scoring" button is clicked, the provided community ID and API key are used to make a GET request to the Gitcoin Passport Scoring API. The response from the API, which includes the user's Passport score, is then displayed on the page.
 
 The example also includes a "Connect" button that, when clicked, uses the Ethers.js library to request the user's Ethereum address from a Web3 provider (such as MetaMask). The user's address is then displayed on the page.
 

--- a/examples/example-score-a-passport/index.html
+++ b/examples/example-score-a-passport/index.html
@@ -23,7 +23,7 @@
         <h4>Score without required signature</h4>
         <p class="mt-3">
           Enter your scorer ID and API key, which you can get from your
-          <a href="https://scorer.gitcoin.co/">scoring dashboard</a>
+          <a href="https://developer.passport.xyz/">scoring dashboard</a>
         </p>
         <input type="text" id="scorerId" placeholder="Scorer ID" />
         <input type="text" id="apiKey" placeholder="API Key" />
@@ -36,7 +36,7 @@
         <h4>Score with required signature</h4>
         <p class="mt-3">
           Enter your scorer ID and API key, which you can get from your
-          <a href="https://scorer.gitcoin.co/">scoring dashboard</a>
+          <a href="https://developer.passport.xyz/">scoring dashboard</a>
         </p>
         <input type="text" id="scorerId" placeholder="Scorer ID" />
         <input type="text" id="apiKey" placeholder="API Key" />

--- a/examples/example-score-a-passport/index.html
+++ b/examples/example-score-a-passport/index.html
@@ -62,7 +62,7 @@
     <script>
       let scorerId, apiKey;
 
-      const endpoint = "https://api.scorer.gitcoin.co";
+      const endpoint = "https://api.passport.xyz";
       // const endpoint = "http://127.0.0.1:8002";
       const ethereumButton = document.querySelector(".enableEthereumButton");
       const submitForScoringButton = document.querySelector(

--- a/examples/onchain-stamps-app/src/app/tab-contents.tsx
+++ b/examples/onchain-stamps-app/src/app/tab-contents.tsx
@@ -166,10 +166,10 @@ const ContentBelowThreshold = () => {
             <br />
             <p>Did you remember to connect and click "Query Passport?"</p>
             <br />
-            <p>You can go to the <Link href="https://passport.gitcoin.co" color='teal.500' isExternal>Passport App </Link> and add more stamps to your Passport.</p>
+            <p>You can go to the <Link href="https://app.passport.xyz" color='teal.500' isExternal>Passport App </Link> and add more stamps to your Passport.</p>
             <p>These Stamps can then be migrated onchain with a single click!</p>
             <br />
-            <p>In the meantime you can read our <Link href="https://docs.gitcoin.co" color='teal.500' isExternal> awesome documentation </Link> to learn more about Gitcoin passport</p>
+            <p>In the meantime you can read our <Link href="https://docs.passport.xyz" color='teal.500' isExternal> awesome documentation </Link> to learn more about Gitcoin passport</p>
             <br />
             <p> You can also check your attestations using the <Link href="https://base-goerli.easscan.org" color='teal.500' isExternal>Ethereum Attestation Service explorer </Link></p>
             <p> There, you can search for your address and see your Attestations in the browser.</p>

--- a/examples/onchain-stamps-app/src/app/tab-contents.tsx
+++ b/examples/onchain-stamps-app/src/app/tab-contents.tsx
@@ -169,7 +169,7 @@ const ContentBelowThreshold = () => {
             <p>You can go to the <Link href="https://app.passport.xyz" color='teal.500' isExternal>Passport App </Link> and add more stamps to your Passport.</p>
             <p>These Stamps can then be migrated onchain with a single click!</p>
             <br />
-            <p>In the meantime you can read our <Link href="https://docs.passport.xyz" color='teal.500' isExternal> awesome documentation </Link> to learn more about Gitcoin passport</p>
+            <p>In the meantime you can read our <Link href="https://docs.passport.human.tech" color='teal.500' isExternal> awesome documentation </Link> to learn more about Gitcoin passport</p>
             <br />
             <p> You can also check your attestations using the <Link href="https://base-goerli.easscan.org" color='teal.500' isExternal>Ethereum Attestation Service explorer </Link></p>
             <p> There, you can search for your address and see your Attestations in the browser.</p>

--- a/examples/passport-gated-content-app/README.md
+++ b/examples/passport-gated-content-app/README.md
@@ -6,7 +6,7 @@ This is a simple demo app that shows how to use the Scorer API to retrieve user 
 
 ## Getting Started
 
-This repository contains source code to accompany a "passport gating" walkthrough tutorial at docs.gitcoin.co.
+This repository contains source code to accompany a "passport gating" walkthrough tutorial at docs.passport.xyz.
 
 You can find step-by-step instructions for setting up and running this app in the tutorial.
 

--- a/examples/passport-gated-content-app/README.md
+++ b/examples/passport-gated-content-app/README.md
@@ -6,7 +6,7 @@ This is a simple demo app that shows how to use the Scorer API to retrieve user 
 
 ## Getting Started
 
-This repository contains source code to accompany a "passport gating" walkthrough tutorial at docs.passport.xyz.
+This repository contains source code to accompany a "passport gating" walkthrough tutorial at docs.passport.human.tech.
 
 You can find step-by-step instructions for setting up and running this app in the tutorial.
 

--- a/examples/passport-gated-content-app/src/app/boilerplate.tsx
+++ b/examples/passport-gated-content-app/src/app/boilerplate.tsx
@@ -6,9 +6,9 @@ const APIKEY = process.env.NEXT_PUBLIC_GC_API_KEY
 const SCORERID = process.env.NEXT_PUBLIC_GC_SCORER_ID
 
 // endpoint for submitting passport
-const SUBMIT_PASSPORT_URI = 'https://api.scorer.gitcoin.co/registry/submit-passport'
+const SUBMIT_PASSPORT_URI = 'https://api.passport.xyz/registry/submit-passport'
 // endpoint for getting the signing message
-const SIGNING_MESSAGE_URI = 'https://api.scorer.gitcoin.co/registry/signing-message'
+const SIGNING_MESSAGE_URI = 'https://api.passport.xyz/registry/signing-message'
 // score needed to see hidden message
 const thresholdNumber = 20
 const headers = APIKEY ? ({

--- a/examples/passport-gated-content-app/src/app/boilerplate.tsx
+++ b/examples/passport-gated-content-app/src/app/boilerplate.tsx
@@ -137,7 +137,7 @@ export default function Passport() {
     /* this is the UI for the app */
     <div style={styles.main}>
       <h1 style={styles.heading}>Are you a trusted user? 🫶</h1>
-      <p style={styles.configurePassport}>Configure your passport <a style={styles.linkStyle} target="_blank" href="https://passport.gitcoin.co/#/dashboard">here</a></p>
+      <p style={styles.configurePassport}>Configure your passport <a style={styles.linkStyle} target="_blank" href="https://app.passport.xyz/#/dashboard">here</a></p>
       <p style={styles.configurePassport}>Once you've added more stamps to your passport, submit your passport again to recalculate your score.</p>
       <p style={styles.configurePassport}>If you have a score above 20, a Github stamp AND a Lens stamp, you are a trusted user! Click the Check Users button to find out!</p>
       <div style={styles.buttonContainer}>

--- a/examples/passport-gated-content-app/src/app/page.tsx
+++ b/examples/passport-gated-content-app/src/app/page.tsx
@@ -8,9 +8,9 @@ const APIKEY = process.env.NEXT_PUBLIC_GC_API_KEY
 const SCORERID = process.env.NEXT_PUBLIC_GC_SCORER_ID
 
 // endpoint for submitting passport
-const SUBMIT_PASSPORT_URI = 'https://api.scorer.gitcoin.co/registry/submit-passport'
+const SUBMIT_PASSPORT_URI = 'https://api.passport.xyz/registry/submit-passport'
 // endpoint for getting the signing message
-const SIGNING_MESSAGE_URI = 'https://api.scorer.gitcoin.co/registry/signing-message'
+const SIGNING_MESSAGE_URI = 'https://api.passport.xyz/registry/signing-message'
 // score needed to see hidden message
 const thresholdNumber = 20
 const headers = APIKEY ? ({
@@ -93,7 +93,7 @@ export default function Passport() {
 
   async function getScore() {
     setScore('')
-    const GET_PASSPORT_SCORE_URI = `https://api.scorer.gitcoin.co/registry/score/${SCORERID}/${address}`
+    const GET_PASSPORT_SCORE_URI = `https://api.passport.xyz/registry/score/${SCORERID}/${address}`
     try {
       const response = await fetch(GET_PASSPORT_SCORE_URI, {
         headers

--- a/examples/passport-gated-content-app/src/app/tab-contents.tsx
+++ b/examples/passport-gated-content-app/src/app/tab-contents.tsx
@@ -137,7 +137,7 @@ const ContentBelowThreshold = ({ score }) => {
             <p>You can go to the <Link href="https://app.passport.xyz" color='teal.500' isExternal>Passport App </Link> and add more stamps to your Passport.</p>
             <p>When you have enough stamps to generate a score above 20, you can come back and join our DAO!</p>
             <br />
-            <p>In the meantime you can read our <Link href="https://docs.passport.xyz" color='teal.500' isExternal> awesome documentation </Link> to learn more about Gitcoin passport</p>
+            <p>In the meantime you can read our <Link href="https://docs.passport.human.tech" color='teal.500' isExternal> awesome documentation </Link> to learn more about Gitcoin passport</p>
         </>
     )
 }

--- a/examples/passport-gated-content-app/src/app/tab-contents.tsx
+++ b/examples/passport-gated-content-app/src/app/tab-contents.tsx
@@ -44,7 +44,7 @@ const Welcome = () => {
             <p>A Passport score is calculated from the stamps held in your Passport. The more stamps, the higher the score.</p>
             <br />
             <p><b>Get started by connecting your wallet and then connecting your Passport</b></p>
-            <p>To add stamps to your Passport, visit the <Link href="https://passport.gitcoin.co" color='teal.500' isExternal>Passport App</Link>.</p>
+            <p>To add stamps to your Passport, visit the <Link href="https://app.passport.xyz" color='teal.500' isExternal>Passport App</Link>.</p>
         </>
     )
 }
@@ -134,10 +134,10 @@ const ContentBelowThreshold = ({ score }) => {
             <br />
             <p>Unfortunately, you do not quite meet the eligibility criteria.</p>
             <p> {text} </p>
-            <p>You can go to the <Link href="https://passport.gitcoin.co" color='teal.500' isExternal>Passport App </Link> and add more stamps to your Passport.</p>
+            <p>You can go to the <Link href="https://app.passport.xyz" color='teal.500' isExternal>Passport App </Link> and add more stamps to your Passport.</p>
             <p>When you have enough stamps to generate a score above 20, you can come back and join our DAO!</p>
             <br />
-            <p>In the meantime you can read our <Link href="https://docs.gitcoin.co" color='teal.500' isExternal> awesome documentation </Link> to learn more about Gitcoin passport</p>
+            <p>In the meantime you can read our <Link href="https://docs.passport.xyz" color='teal.500' isExternal> awesome documentation </Link> to learn more about Gitcoin passport</p>
         </>
     )
 }

--- a/examples/score-gating/README.md
+++ b/examples/score-gating/README.md
@@ -8,7 +8,7 @@ This sample app connects to a user's wallet, then fetches their passport score f
 
 ### Create your API key and Scorer
 
-1. Create your API key by going to [Gitcoin Passport Scorer](https://scorer.gitcoin.co) and clicking on the "API Keys" section.
+1. Create your API key by going to [Gitcoin Passport Scorer](https://developer.passport.xyz) and clicking on the "API Keys" section.
    Then create a `.env.local` file and copy the contents of the `example.env.local` file into it.
    Replace `SCORER_API_KEY` with your API key.
 

--- a/examples/score-gating/components/gate.js
+++ b/examples/score-gating/components/gate.js
@@ -16,7 +16,7 @@ export default function Gate() {
   useEffect(() => {
     setNonce("");
     async function fetchPassportScore() {
-      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
       //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
       //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
       //    expose our scorer API key to the frontend.

--- a/examples/score-gating/components/gate.js
+++ b/examples/score-gating/components/gate.js
@@ -16,7 +16,7 @@ export default function Gate() {
   useEffect(() => {
     setNonce("");
     async function fetchPassportScore() {
-      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
+      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.human.tech/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
       //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
       //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
       //    expose our scorer API key to the frontend.

--- a/examples/score-gating/components/gate.js
+++ b/examples/score-gating/components/gate.js
@@ -16,7 +16,7 @@ export default function Gate() {
   useEffect(() => {
     setNonce("");
     async function fetchPassportScore() {
-      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.gitcoin.co/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
       //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
       //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
       //    expose our scorer API key to the frontend.
@@ -59,7 +59,7 @@ export default function Gate() {
       //    }
       const submitResponse = await axios.post("/api/submit-passport", {
         address: address, // Required: The user's address you'd like to score.
-        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://scorer.gitcoin.co/
+        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://developer.passport.xyz/
         signature: data, // Optional: The signature of the message returned in Step #1
         nonce: nonce, // Optional: The nonce returned in Step #1
       });

--- a/examples/score-gating/pages/api/score/[scorer_id]/[address].js
+++ b/examples/score-gating/pages/api/score/[scorer_id]/[address].js
@@ -16,7 +16,7 @@ async function fetchScore(address, scorerId) {
     },
   };
   const { data } = await axios.get(
-    `https://api.scorer.gitcoin.co/registry/score/${scorerId}/${address}`,
+    `https://api.passport.xyz/registry/score/${scorerId}/${address}`,
     axiosGetScoreConfig
   );
 

--- a/examples/score-gating/pages/api/scorer-message.js
+++ b/examples/score-gating/pages/api/scorer-message.js
@@ -18,7 +18,7 @@ async function fetchMessageAndNonce() {
     },
   };
   const { data } = await axios.get(
-    "https://api.scorer.gitcoin.co/registry/signing-message",
+    "https://api.passport.xyz/registry/signing-message",
     axiosSigningMessageConfig
   );
   return data;

--- a/examples/score-gating/pages/api/submit-passport.js
+++ b/examples/score-gating/pages/api/submit-passport.js
@@ -23,7 +23,7 @@ async function submitPassport(address, community, signature, nonce) {
     nonce,
   };
   const { data } = await axios.post(
-    "https://api.scorer.gitcoin.co/registry/submit-passport",
+    "https://api.passport.xyz/registry/submit-passport",
     axiosSubmitPassportData,
     axiosSubmitPassportConfig
   );

--- a/examples/score-gating/pages/dashboard.js
+++ b/examples/score-gating/pages/dashboard.js
@@ -35,7 +35,7 @@ export default function Dashboard() {
   }, [address, initialAddress]);
 
   async function scorePassport() {
-    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.gitcoin.co/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
     //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
     //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
     //    expose our scorer API key to the frontend.
@@ -80,7 +80,7 @@ export default function Dashboard() {
       //    }
       const submitResponse = await axios.post("/api/submit-passport", {
         address: address, // Required: The user's address you'd like to score.
-        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://scorer.gitcoin.co/
+        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://developer.passport.xyz/
         signature: data, // Optional: The signature of the message returned in Step #1
         nonce: nonce, // Optional: The nonce returned in Step #1
       });
@@ -133,7 +133,7 @@ export default function Dashboard() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.gitcoin.co/"
+              href="https://www.passport.xyz/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/score-gating/pages/dashboard.js
+++ b/examples/score-gating/pages/dashboard.js
@@ -35,7 +35,7 @@ export default function Dashboard() {
   }, [address, initialAddress]);
 
   async function scorePassport() {
-    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
+    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.human.tech/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
     //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
     //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
     //    expose our scorer API key to the frontend.
@@ -133,7 +133,7 @@ export default function Dashboard() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.passport.xyz/"
+              href="https://passport.human.tech/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/score-gating/pages/dashboard.js
+++ b/examples/score-gating/pages/dashboard.js
@@ -35,7 +35,7 @@ export default function Dashboard() {
   }, [address, initialAddress]);
 
   async function scorePassport() {
-    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
     //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
     //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
     //    expose our scorer API key to the frontend.

--- a/examples/score-gating/pages/denied.js
+++ b/examples/score-gating/pages/denied.js
@@ -27,7 +27,7 @@ export default function Denied() {
   }, [address]);
 
   async function scorePassport() {
-    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.gitcoin.co/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
     //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
     //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
     //    expose our scorer API key to the frontend.
@@ -72,7 +72,7 @@ export default function Denied() {
       //    }
       const submitResponse = await axios.post("/api/submit-passport", {
         address: address, // Required: The user's address you'd like to score.
-        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://scorer.gitcoin.co/
+        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://developer.passport.xyz/
         signature: data, // Optional: The signature of the message returned in Step #1
         nonce: nonce, // Optional: The nonce returned in Step #1
       });
@@ -126,7 +126,7 @@ export default function Denied() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.gitcoin.co/"
+              href="https://www.passport.xyz/"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -157,7 +157,7 @@ export default function Denied() {
             className={dstyles.link}
             target="_blank"
             rel="noreferrer"
-            href="https://passport.gitcoin.co"
+            href="https://app.passport.xyz"
           >
             Click here to increase your score.
           </a>

--- a/examples/score-gating/pages/denied.js
+++ b/examples/score-gating/pages/denied.js
@@ -27,7 +27,7 @@ export default function Denied() {
   }, [address]);
 
   async function scorePassport() {
-    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
     //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
     //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
     //    expose our scorer API key to the frontend.

--- a/examples/score-gating/pages/denied.js
+++ b/examples/score-gating/pages/denied.js
@@ -27,7 +27,7 @@ export default function Denied() {
   }, [address]);
 
   async function scorePassport() {
-    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
+    //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.human.tech/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
     //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
     //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
     //    expose our scorer API key to the frontend.
@@ -126,7 +126,7 @@ export default function Denied() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.passport.xyz/"
+              href="https://passport.human.tech/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/score-gating/pages/index.js
+++ b/examples/score-gating/pages/index.js
@@ -20,7 +20,7 @@ export default function Home() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.gitcoin.co/"
+              href="https://www.passport.xyz/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/score-gating/pages/index.js
+++ b/examples/score-gating/pages/index.js
@@ -20,7 +20,7 @@ export default function Home() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.passport.xyz/"
+              href="https://passport.human.tech/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/score-showcase/README.md
+++ b/examples/score-showcase/README.md
@@ -8,7 +8,7 @@ This sample app connects to a user's wallet, then fetches their passport score f
 
 ### Create your API key and Scorer
 
-1. Create your API key by going to [Gitcoin Passport Scorer](https://scorer.gitcoin.co) and clicking on the "API Keys" section.
+1. Create your API key by going to [Gitcoin Passport Scorer](https://developer.passport.xyz) and clicking on the "API Keys" section.
    Then create a `.env.local` file and copy the contents of the `example.env.local` file into it.
    Replace `SCORER_API_KEY` with your API key.
 

--- a/examples/score-showcase/components/score.js
+++ b/examples/score-showcase/components/score.js
@@ -25,7 +25,7 @@ export default function Score() {
     setNonce("");
     setPassportScore(0);
     async function fetchPassportScore() {
-      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.gitcoin.co/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
       //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
       //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
       //    expose our scorer API key to the frontend.
@@ -64,7 +64,7 @@ export default function Score() {
       //    }
       const submitResponse = await axios.post("/api/submit-passport", {
         address: address, // Required: The user's address you'd like to score.
-        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://scorer.gitcoin.co/
+        community: process.env.NEXT_PUBLIC_SCORER_ID, // Required: get this from one of your scorers in the Scorer API dashboard https://developer.passport.xyz/
         signature: data, // Optional: The signature of the message returned in step #1
         nonce: nonce, // Optional: The nonce returned in Step #1
       });

--- a/examples/score-showcase/components/score.js
+++ b/examples/score-showcase/components/score.js
@@ -25,7 +25,7 @@ export default function Score() {
     setNonce("");
     setPassportScore(0);
     async function fetchPassportScore() {
-      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/scorer-api/endpoint-definition#submit-passport)
+      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
       //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
       //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
       //    expose our scorer API key to the frontend.

--- a/examples/score-showcase/components/score.js
+++ b/examples/score-showcase/components/score.js
@@ -25,7 +25,7 @@ export default function Score() {
     setNonce("");
     setPassportScore(0);
     async function fetchPassportScore() {
-      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.xyz/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
+      //  Step #1 (Optional, only required if using the "signature" param when submitting a user's passport. See https://docs.passport.human.tech/building-with-passport/stamps/passport-api-v1/api-reference#submit-and-retrieve-latest-score-for-a-single-address)
       //    We call our /api/scorer-message endpoint (/pages/api/scorer-message.js) which internally calls /registry/signing-message
       //    on the scorer API. Instead of calling /registry/signing-message directly, we call it via our api endpoint so we do not
       //    expose our scorer API key to the frontend.

--- a/examples/score-showcase/pages/api/score/[scorer_id]/[address].js
+++ b/examples/score-showcase/pages/api/score/[scorer_id]/[address].js
@@ -16,7 +16,7 @@ async function fetchScore(address, scorerId) {
     },
   };
   const { data } = await axios.get(
-    `https://api.scorer.gitcoin.co/registry/score/${scorerId}/${address}`,
+    `https://api.passport.xyz/registry/score/${scorerId}/${address}`,
     axiosGetScoreConfig
   );
 

--- a/examples/score-showcase/pages/api/scorer-message.js
+++ b/examples/score-showcase/pages/api/scorer-message.js
@@ -18,7 +18,7 @@ async function fetchMessageAndNonce() {
     },
   };
   const { data } = await axios.get(
-    "https://api.scorer.gitcoin.co/registry/signing-message",
+    "https://api.passport.xyz/registry/signing-message",
     axiosSigningMessageConfig
   );
   return data;

--- a/examples/score-showcase/pages/api/submit-passport.js
+++ b/examples/score-showcase/pages/api/submit-passport.js
@@ -23,7 +23,7 @@ async function submitPassport(address, community, signature, nonce) {
     nonce,
   };
   const { data } = await axios.post(
-    "https://api.scorer.gitcoin.co/registry/submit-passport",
+    "https://api.passport.xyz/registry/submit-passport",
     axiosSubmitPassportData,
     axiosSubmitPassportConfig
   );

--- a/examples/score-showcase/pages/index.js
+++ b/examples/score-showcase/pages/index.js
@@ -23,7 +23,7 @@ export default function Home() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.gitcoin.co/"
+              href="https://www.passport.xyz/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/score-showcase/pages/index.js
+++ b/examples/score-showcase/pages/index.js
@@ -23,7 +23,7 @@ export default function Home() {
         <div className={styles.description}>
           <div>
             <a
-              href="https://www.passport.xyz/"
+              href="https://passport.human.tech/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/examples/stamp-collector/README.md
+++ b/examples/stamp-collector/README.md
@@ -16,4 +16,4 @@ You should see your stamps displayed in the browser. Icons are common to all sta
 
 ## Learn more
 
-Visit the [Passport docs](http://passport.gitcoin.co)
+Visit the [Passport docs](https://app.passport.xyz)

--- a/examples/stamp-collector/src/app/boilerplate.tsx
+++ b/examples/stamp-collector/src/app/boilerplate.tsx
@@ -6,9 +6,9 @@ const APIKEY = process.env.NEXT_PUBLIC_GC_API_KEY
 const SCORERID = process.env.NEXT_PUBLIC_GC_SCORER_ID
 
 // endpoint for submitting passport
-const SUBMIT_PASSPORT_URI = 'https://api.scorer.gitcoin.co/registry/submit-passport'
+const SUBMIT_PASSPORT_URI = 'https://api.passport.xyz/registry/submit-passport'
 // endpoint for getting the signing message
-const SIGNING_MESSAGE_URI = 'https://api.scorer.gitcoin.co/registry/signing-message'
+const SIGNING_MESSAGE_URI = 'https://api.passport.xyz/registry/signing-message'
 // score needed to see hidden message
 const thresholdNumber = 20
 const headers = APIKEY ? ({

--- a/examples/stamp-collector/src/app/boilerplate.tsx
+++ b/examples/stamp-collector/src/app/boilerplate.tsx
@@ -137,7 +137,7 @@ export default function Passport() {
     /* this is the UI for the app */
     <div style={styles.main}>
       <h1 style={styles.heading}>Are you a trusted user? 🫶</h1>
-      <p style={styles.configurePassport}>Configure your passport <a style={styles.linkStyle} target="_blank" href="https://passport.gitcoin.co/#/dashboard">here</a></p>
+      <p style={styles.configurePassport}>Configure your passport <a style={styles.linkStyle} target="_blank" href="https://app.passport.xyz/#/dashboard">here</a></p>
       <p style={styles.configurePassport}>Once you've added more stamps to your passport, submit your passport again to recalculate your score.</p>
       <p style={styles.configurePassport}>If you have a score above 20, a Github stamp AND a Lens stamp, you are a trusted user! Click the Check Users button to find out!</p>
       <div style={styles.buttonContainer}>

--- a/examples/stamp-collector/src/app/page.tsx
+++ b/examples/stamp-collector/src/app/page.tsx
@@ -52,7 +52,7 @@ export default function Passport() {
 
   async function getStamps() {
     const stampDataArray = []
-    const GET_PASSPORT_STAMPS_URI = `https://api.scorer.gitcoin.co/registry/stamps/${address}?include_metadata=true`
+    const GET_PASSPORT_STAMPS_URI = `https://api.passport.xyz/registry/stamps/${address}?include_metadata=true`
     try {
       const response: Response = await fetch(GET_PASSPORT_STAMPS_URI, { headers })
       const data = await response.json()

--- a/interface/components/Dashboard.tsx
+++ b/interface/components/Dashboard.tsx
@@ -65,7 +65,7 @@ const General = ({ className }: { className: string }) => {
       />
       <QuickLink
         text="API Playground"
-        url="https://api.scorer.gitcoin.co/docs"
+        url="https://api.passport.xyz/docs"
         icon={<CommandLineIcon className={iconClassName} />}
         className={linkClassName}
       />

--- a/interface/components/Dashboard.tsx
+++ b/interface/components/Dashboard.tsx
@@ -53,7 +53,7 @@ const General = ({ className }: { className: string }) => {
       />
       <QuickLink
         text="Developer Docs"
-        url="https://docs.passport.xyz/"
+        url="https://docs.passport.human.tech/"
         icon={<BookOpenIcon className={iconClassName} />}
         className={linkClassName}
       />
@@ -71,7 +71,7 @@ const General = ({ className }: { className: string }) => {
       />
       <QuickLink
         text="What is a Scorer?"
-        url="https://docs.passport.xyz/building-with-passport/passport-api/getting-access#projects-and-project-id"
+        url="https://docs.passport.human.tech/building-with-passport/passport-api/getting-access#projects-and-project-id"
         icon={<QuestionMarkCircleIcon className={iconClassName} />}
         className={linkClassName}
       />
@@ -96,20 +96,20 @@ const StampsAPI = ({ className }: { className?: string }) => {
       />
       <QuickLink
         text="Overview"
-        url="https://docs.passport.xyz/building-with-passport/stamps/passport-api"
+        url="https://docs.passport.human.tech/building-with-passport/stamps/passport-api"
         className={linkClassName}
         icon={<WindowIcon className={iconClassName} />}
       />
       <QuickLink
         text="Quick Start Guide"
         className={linkClassName}
-        url="https://docs.passport.xyz/building-with-passport/stamps/passport-api/quick-start-guide"
+        url="https://docs.passport.human.tech/building-with-passport/stamps/passport-api/quick-start-guide"
         icon={<FlagIcon className={iconClassName} />}
       />
       <QuickLink
         text="API Reference"
         className={linkClassName}
-        url="https://docs.passport.xyz/building-with-passport/passport-api/api-reference"
+        url="https://docs.passport.human.tech/building-with-passport/passport-api/api-reference"
         icon={<ListBulletIcon className={iconClassName} />}
       />
     </div>
@@ -132,14 +132,14 @@ const ModelsAPI = ({ className }: { className?: string }) => {
       />
       <QuickLink
         text="Overview"
-        url="https://docs.passport.xyz/building-with-passport/models"
+        url="https://docs.passport.human.tech/building-with-passport/models"
         className={linkClassName}
         icon={<WindowIcon className={iconClassName} />}
       />
       <QuickLink
         text="API Reference"
         className={linkClassName}
-        url="https://docs.passport.xyz/building-with-passport/models/api-reference"
+        url="https://docs.passport.human.tech/building-with-passport/models/api-reference"
         icon={<ListBulletIcon className={iconClassName} />}
       />
     </div>

--- a/interface/components/Footer.tsx
+++ b/interface/components/Footer.tsx
@@ -49,7 +49,7 @@ const Footer = ({ mode, className, hideLinks }: FooterProps): JSX.Element => {
           <img src={assets.githubLogo} alt="Github Logo" />
         </a>
         <a
-          href="https://docs.passport.xyz"
+          href="https://docs.passport.human.tech"
           target="_blank"
           rel="noopener noreferrer"
           className=""

--- a/interface/components/UseCaseModal.tsx
+++ b/interface/components/UseCaseModal.tsx
@@ -356,7 +356,7 @@ const UseCaseDetails = ({
           />
           <FormHelperText>
             We recommend using a score threshold of 20. Learn more about{" "}
-            <a className="text-purple-gitcoinpurple" href="https://docs.passport.xyz/building-with-passport/stamps/major-concepts/scoring-thresholds">
+            <a className="text-purple-gitcoinpurple" href="https://docs.passport.human.tech/building-with-passport/stamps/major-concepts/scoring-thresholds">
               score thresholds
             </a>
             .

--- a/interface/utils/onboard.ts
+++ b/interface/utils/onboard.ts
@@ -16,7 +16,7 @@ const walletConnectOptions: WalletConnectOptions = {
 
 const onBoardExploreUrl =
   (process.env.NEXT_PUBLIC_WEB3_ONBOARD_EXPLORE_URL as string) ||
-  "https://passport.gitcoin.co/";
+  "https://app.passport.xyz/";
 
 const walletConnect = walletConnectModule(walletConnectOptions);
 const injected = injectedModule();


### PR DESCRIPTION
## Why

The `gitcoin.co` zone lost its delegation on 18 August 2026. We do not control that zone and the decision was to leave the old routes off, so every `*.gitcoin.co` host referenced here now returns NXDOMAIN. Callers get a DNS failure, not an HTTP error.

## What changed

Three commits, kept separate.

**1. `api.scorer.gitcoin.co` → `api.passport.xyz`** — 29 occurrences across 19 files. Two are shipped surfaces rather than samples: the API Playground link in the developer portal (`interface/components/Dashboard.tsx`) and `api/registry/bulk-mbd-analysis.md`. The rest is `examples/` sample code, which is the most likely route back onto the dead host for a new integrator. Both target paths were checked live — `/docs` serves the Passport API Playground and `/admin` serves the Django admin login.

**2. The onboard explore URL fallback** — `interface/utils/onboard.ts` hardcoded `https://passport.gitcoin.co/` as the default whenever `NEXT_PUBLIC_WEB3_ONBOARD_EXPLORE_URL` is unset. Now `https://app.passport.xyz/`.

**3. Remaining retired hosts in samples and docs:**

| Old | New |
|---|---|
| `passport.gitcoin.co` | `app.passport.xyz` |
| `scorer.gitcoin.co` | `developer.passport.xyz` |
| `docs.gitcoin.co` | `docs.passport.xyz` |
| `docs.passport.gitcoin.co` | `docs.passport.xyz` |
| `www.gitcoin.co` | `www.passport.xyz` |

Every replacement target returns 200.

## Deliberately not changed

A blanket find-and-replace would have corrupted these, so they were excluded on purpose:

- **`s3://public.scorer.gitcoin.co/passport_scores/`** in two tests is an **S3 bucket name**, not a DNS host. Rewriting it would point at a bucket that does not exist.
- **Recorded `Host` headers** in the lambda test fixtures are test input, not live configuration.
- **`load_tests/*.ipynb`** contain recorded run output. That is a historical record, and editing it would falsify it.
- **`core-alb.private.gitcoin.co`** is an internal name on a private hosted zone. Private zones resolve inside the VPC independently of the public parent, so the public zone loss does not affect it. Worth an infra confirmation, but not a string change.
- **The `*.gitcoin.co` block rule** in `infra/lib/scorer/routing-rules.ts` is deliberate and still correct.
- **`package-lock.json` funding URLs** are third-party ethers.js metadata.

## Also needs doing, outside a PR

Two items this cannot reach:

1. **The repo `homepage` field** is still `https://api.scorer.gitcoin.co/docs`, a dead link on a public repo. Suggest `https://docs.passport.xyz`. That is a settings change.
2. **The developer portal's production API base URL.** The shipped bundle at `developer.passport.xyz` calls `https://api.scorer.gitcoin.co/account/api-key`, so API key create, rename and list are failing. `NEXT_PUBLIC_PASSPORT_SCORER_BACKEND` is injected at build time from 1Password, not from this repo, so it needs a vault update and a redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)