### PR TITLE
fix(passport-api): add timeout + ContentTypeError handling to model fetch()

### DIFF
--- a/api/passport/api.py
+++ b/api/passport/api.py
@@ -159,9 +159,29 @@ async def fetch(session, url, data):
     headers = {"Content-Type": "application/json"}
     try:
         async with session.post(
-            url, data=json.dumps(data), headers=headers
+            url,
+            data=json.dumps(data),
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=10),
         ) as response:
-            body = await response.json()
+            try:
+                body = await response.json()
+            except aiohttp.ContentTypeError:
+                body_preview = (await response.text())[:300]
+                log.error(
+                    "ContentTypeError fetching %s — ALB returned non-JSON (status=%s, preview=%r)",
+                    url,
+                    response.status,
+                    body_preview,
+                )
+                return {
+                    "status": 500,
+                    "data": {
+                        "human_probability": -1,
+                        "n_transactions": -1,
+                        "error": "unexpected content type from model endpoint",
+                    },
+                }
             return {"status": response.status, "data": body.get("data")}
     except Exception as e:
         log.error(f"Error fetching {url}", exc_info=True)


### PR DESCRIPTION
## Problem

`fetch()` in `api/passport/api.py` makes `aiohttp` POST calls to model-predict ALB endpoints with two issues:

1. **No timeout.** The ALB has a 60s idle timeout. When a model Lambda is slow or stale, the client waits the full 60s before receiving an HTML error page, then hits `ContentTypeError` on `response.json()`. Datadog shows 1–17 of these per day since 08-12, predominantly `base-model-predict`.

2. **`ContentTypeError` is lost in the broad `except Exception`.** The log entry has no response body — no way to tell if the ALB is returning a 502, 504, or something else. Makes root-cause tracing (e.g. passportxyz/passport#3126) much harder.

## Fix

- Adds `aiohttp.ClientTimeout(total=10)` to `session.post()` — fails in 10s instead of waiting 60s for an ALB HTML timeout page.
- Catches `aiohttp.ContentTypeError` specifically before the broad `except`, reads the first 300 chars of the response body, and logs status + preview. This will surface what the ALB is actually returning the next time it fires.

## What this does NOT fix
The root cause (likely Lambda image-digest mismatch per passportxyz/passport#3126) is infra — this is a resilience + diagnostics improvement only.

## Relates to
holonym-foundation/internal-docs#2672