### PR TITLE
fix(scorer): make track_usage / atrack_usage actually write rejection rows

### DIFF
--- a/api/account/migrations/0056_make_accountapikeyanalytics_api_key_nullable.py
+++ b/api/account/migrations/0056_make_accountapikeyanalytics_api_key_nullable.py
@@ -1,0 +1,23 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("account", "0055_walletgroup_models"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="accountapikeyanalytics",
+            name="api_key",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="analytics",
+                to="account.accountapikey",
+            ),
+        ),
+    ]

--- a/api/account/models.py
+++ b/api/account/models.py
@@ -332,7 +332,11 @@ class AccountAPIKey(AbstractAPIKey):
 
 class AccountAPIKeyAnalytics(models.Model):
     api_key = models.ForeignKey(
-        AccountAPIKey, on_delete=models.CASCADE, related_name="analytics"
+        AccountAPIKey,
+        on_delete=models.CASCADE,
+        related_name="analytics",
+        null=True,
+        blank=True,
     )
     created_at = models.DateTimeField(
         auto_now_add=True,

--- a/api/registry/api/utils.py
+++ b/api/registry/api/utils.py
@@ -157,18 +157,16 @@ def track_usage(request: HttpRequest, key: str, status_code: int) -> None:
     Track API key usage regardless of authentication outcome
     """
     try:
-        api_key = AccountAPIKey.objects.filter(prefix=key[:8]).first()
+        api_key = AccountAPIKey.objects.filter(prefix=key[:8]).first() if key else None
 
         AccountAPIKeyAnalytics.objects.create(
             api_key=api_key,
             path=request.path,
-            method=request.method,
             status_code=status_code,
-            api_key_id=api_key.id if api_key else None,
             error="Unauthorized request",
         )
     except Exception:
-        pass
+        log.exception("track_usage failed to record rejected request")
 
 
 class ApiKey(APIKeyHeader):
@@ -255,14 +253,11 @@ async def atrack_usage(request, key: str, status_code: int) -> None:
         await AccountAPIKeyAnalytics.objects.acreate(
             api_key=api_key,
             path=request.path,
-            method=request.method,
             status_code=status_code,
-            api_key_id=api_key.id if api_key else None,
-            ip_address=request.META.get("REMOTE_ADDR"),
-            user_agent=request.META.get("HTTP_USER_AGENT", ""),
+            error="Unauthorized request",
         )
     except Exception as e:
-        pass
+        log.exception("atrack_usage failed to record rejected request: %s", e)
 
 
 async def aapi_key(request):


### PR DESCRIPTION
## Problem

`AccountAPIKeyAnalytics` rows for rejected API requests have never been written. Three silent faults, any one fatal:

1. **Invalid keyword args** — both `track_usage` and `atrack_usage` passed `method=`, and `atrack_usage` also passed `ip_address=` and `user_agent=`. None of these fields exist on `AccountAPIKeyAnalytics`. Every call raised `TypeError`.
2. **NOT NULL violation** — `api_key` was a non-nullable FK but all call sites pass `key=""`, so the prefix lookup always returns `None`, which violates the constraint.
3. **Silent failures** — `except Exception: pass` (sync) and `except Exception as e: pass` with `e` never used (async) — no row written, nothing logged.

## Fix

- Remove the three unknown keyword arguments (`method`, `ip_address`, `user_agent`) from both `create()` / `acreate()` calls.
- Migration 0056: make `AccountAPIKeyAnalytics.api_key` nullable so unattributable 401s (missing or unknown key) can still be recorded with `api_key=None`.
- Replace silent `except: pass` with `log.exception()` so any future failures surface in the logs.

## Files changed

- `api/account/models.py` — `api_key` FK: add `null=True, blank=True`
- `api/account/migrations/0056_make_accountapikeyanalytics_api_key_nullable.py` — migration
- `api/registry/api/utils.py` — `track_usage` and `atrack_usage`: remove invalid fields, log exceptions

## Test plan

- [ ] Send a request with a missing `X-API-Key` header — confirm a row appears in `account_accountapikeyanalytics` with `api_key=NULL`, `status_code=401`, `error="Unauthorized request"`
- [ ] Send with an invalid/expired key — confirm row is written with the matched api_key FK (or NULL if key is unrecognised)
- [ ] No regression on successful auth — existing rows from the `FF_API_ANALYTICS` path unaffected

Fixes holonym-foundation/internal-docs#3008

🤖 Generated with [Claude Code](https://claude.com/claude-code)